### PR TITLE
[codex] Support dispatched API generation

### DIFF
--- a/.github/workflows/generate-api-version.yml
+++ b/.github/workflows/generate-api-version.yml
@@ -1,4 +1,5 @@
 name: Generate API Version
+run-name: Generate API Version - ${{ inputs['dispatch-id'] || github.run_id }}
 
 on:
   workflow_call:
@@ -7,12 +8,22 @@ on:
         description: Trello card URL
         required: true
         type: string
+      dispatch-id:
+        description: Unique id used by callers to find this workflow run
+        required: false
+        type: string
+        default: ''
   workflow_dispatch:
     inputs:
       trello-card-url:
         description: Trello card URL
         required: true
         type: string
+      dispatch-id:
+        description: Unique id used by callers to find this workflow run
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: write
@@ -87,8 +98,32 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
+      - name: Resolve next Maven package version
+        shell: pwsh
+        run: |
+          [xml]$pom = Get-Content 'src/pom.xml' -Raw
+          $namespace = New-Object System.Xml.XmlNamespaceManager($pom.NameTable)
+          $namespace.AddNamespace('m', 'http://maven.apache.org/POM/4.0.0')
+
+          $versionNode = $pom.SelectSingleNode('/m:project/m:version', $namespace)
+
+          if ($null -eq $versionNode -or [string]::IsNullOrWhiteSpace($versionNode.InnerText)) {
+            throw 'Could not find project version in src/pom.xml.'
+          }
+
+          $currentVersion = $versionNode.InnerText.Trim()
+
+          if ($currentVersion -notmatch '^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$') {
+            throw "Current Maven version '$currentVersion' is not a supported major.minor.patch version."
+          }
+
+          $nextVersion = '{0}.{1}.0' -f $Matches.major, ([int]$Matches.minor + 1)
+
+          "SDK_VERSION=$nextVersion" >> $env:GITHUB_ENV
+          "Resolved next Maven package version $nextVersion from current version $currentVersion." >> $env:GITHUB_STEP_SUMMARY
+
       - name: Update Maven package version
-        run: mvn --batch-mode versions:set -DnewVersion=${{ env.API_VERSION }} -DgenerateBackupPoms=false --file src/pom.xml
+        run: mvn --batch-mode versions:set -DnewVersion=${{ env.SDK_VERSION }} -DgenerateBackupPoms=false --file src/pom.xml
 
       - name: Generate Java classes
         shell: pwsh
@@ -147,7 +182,7 @@ jobs:
             '## Validation'
             '- dotnet restore Generator/Generator.csproj'
             '- dotnet build Generator/Generator.csproj --configuration Release --no-restore'
-            "- Updated src/pom.xml version to $env:API_VERSION"
+            "- Updated src/pom.xml version to $env:SDK_VERSION"
             '- pwsh ./generate.ps1'
             '- mvn --batch-mode -DskipTests package --file src/pom.xml'
             '- mvn resources:resources --file src/pom.xml'


### PR DESCRIPTION
## Summary
- Add an optional `dispatch-id` input to the API generation workflow.
- Use the dispatch id in `run-name` so callers can reliably find and watch the exact workflow run they triggered.
- Preserve the existing workflow updates on this branch for resolving the next Maven package version.

## Validation
- Parsed edited workflow YAML files with Ruby `YAML.load_file`.
- Ran `git diff --check`; only existing line-ending normalization warnings were reported.

## Note
- The local `src/pom.xml` change was left unstaged and is not part of this PR.
