### PR TITLE
fix: update Maven Central signing setup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
         run: ./generate.sh
 
       - name: Set up JDK 17 and Maven Central auth
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -36,8 +36,11 @@ jobs:
           server-username: SONATYPE_USERNAME
           server-password: SONATYPE_TOKEN
           gpg-private-key: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
-          gpg-passphrase: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
           cache: maven
+
+      - name: Verify GPG private key import
+        run: gpg --batch --list-secret-keys --keyid-format LONG
 
       - name: Build
         run: mvn --batch-mode -DskipTests package --file src/pom.xml
@@ -52,12 +55,11 @@ jobs:
         run: mvn org.kordamp.maven:pomchecker-maven-plugin:1.7.0:check-maven-central --file src/pom.xml
 
       - name: Build and deploy to Maven Central
-        run: mvn deploy --batch-mode -Prelease -f src/pom.xml -Dgpg.passphrase="${{ secrets.JRELEASER_GPG_PASSPHRASE }}"
+        run: mvn deploy --batch-mode -Prelease -f src/pom.xml
         env:
           SONATYPE_USERNAME: ${{ secrets.JRELEASER_NEXUS2_USERNAME }}
           SONATYPE_TOKEN: ${{ secrets.JRELEASER_NEXUS2_PASSWORD }}
-          GPG_PRIVATE_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
           DATASET_ID: ${{secrets.INTEGRATIONTESTS_DATASET_ID}}
           API_KEY: ${{secrets.INTEGRATIONTESTS_API_KEY}}
 

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -128,6 +128,12 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>3.1.0</version>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
https://trello.com/c/AgYtEUf6/20659-upgrade-java-release-pipeline

## Summary
- Upgrade publish workflow to actions/setup-java@v5.
- Pass the GPG passphrase using the environment variable name expected by setup-java.
- Add a GPG key import verification step before Maven signing.
- Configure maven-gpg-plugin to use pinentry loopback mode.

## Validation
- Parsed src/pom.xml locally as XML.
- Maven validation was not run locally because mvn is not installed in this environment.