### PR TITLE
Add monthly GitHub Actions Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+      time: "07:00"
+      timezone: Europe/Copenhagen
+    groups:
+      actions-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    labels: ["dependencies"]


### PR DESCRIPTION
## What changed

- Add or standardize Dependabot version updates for GitHub Actions.
- Run the update check monthly at 07:00 Europe/Copenhagen.
- Group minor and patch action updates while keeping major updates in separate pull requests.
- Preserve existing Dependabot configuration for other package ecosystems.

## Why

This gives repositories with GitHub Actions a consistent, low-noise maintenance cadence while keeping potentially breaking major action upgrades isolated for review.

## Impact

Dependabot will check GitHub Actions references monthly. No application or runtime behavior changes.

## Validation

- Parsed the resulting configuration as YAML.
- Verified one GitHub Actions update block per repository with the intended schedule and grouping.
- Ran `git diff --cached --check`.
- Application builds and tests were not run because only `.github/dependabot.yml` changed.