### PR TITLE
Codex/skip dependabot integration tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,14 +33,19 @@ jobs:
         run: mvn resources:resources --file src/pom.xml
 
       - name: Test
+        if: ${{ github.actor != 'dependabot[bot]' }}
         run: mvn --batch-mode -Dmaven.test.failure.ignore=true test --file src/pom.xml
         env:
           DATASET_ID: ${{secrets.INTEGRATIONTESTS_DATASET_ID}}
           API_KEY: ${{secrets.INTEGRATIONTESTS_API_KEY}}
 
+      - name: Unit tests
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        run: mvn --batch-mode -DexcludedGroups=integration test --file src/pom.xml
+
       - name: Report
         uses: dorny/test-reporter@v1
-        if: always()
+        if: ${{ always() && github.actor != 'dependabot[bot]' }}
         with:
           name: Maven Tests
           path: src/target/surefire-reports/*.xml

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
         run: ./generate.sh
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.6.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -44,7 +44,7 @@ jobs:
         run: mvn --batch-mode -DexcludedGroups=integration test --file src/pom.xml
 
       - name: Report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v3
         if: ${{ always() && github.actor != 'dependabot[bot]' }}
         with:
           name: Maven Tests

--- a/.github/workflows/generate-api-version.yml
+++ b/.github/workflows/generate-api-version.yml
@@ -81,7 +81,7 @@ jobs:
           "Resolved Relewise.Client version $version." >> $env:GITHUB_STEP_SUMMARY
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.6.0
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
         run: ./generate.sh
 
       - name: Set up JDK 17 and Maven Central auth
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,9 +76,16 @@ Run tests:
 mvn --batch-mode test --file src/pom.xml
 ```
 
+Run tests that do not require integration credentials:
+
+```powershell
+mvn --batch-mode -DexcludedGroups=integration test --file src/pom.xml
+```
+
 ## Testing and Credentials
-- Tests use `DATASET_ID` and `API_KEY` from environment (`TestBase`).
+- Integration tests inherit the `integration` tag and use `DATASET_ID` and `API_KEY` from the environment (`TestBase`).
 - CI injects credentials from secrets.
+- CI excludes integration tests when triggered by Dependabot.
 - If credentials are unavailable locally, explicitly report integration-style test coverage as not run.
 
 ## Validation Policy (CI-Aligned, Pragmatic)

--- a/src/src/test/java/com/relewise/client/ClientConstructionTest.java
+++ b/src/src/test/java/com/relewise/client/ClientConstructionTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ClientConstructionTest extends TestBase {
+public class ClientConstructionTest {
     @Test
     public void testApiKeyEmpty() {
         assertThrows(IllegalArgumentException.class, () -> new Tracker("00000000-0000-0000-0000-000000000001", "", "https://api.relewise.com/"));

--- a/src/src/test/java/com/relewise/client/DateTimeSerializationTest.java
+++ b/src/src/test/java/com/relewise/client/DateTimeSerializationTest.java
@@ -14,7 +14,7 @@ import java.util.concurrent.Callable;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class DateTimeSerializationTest extends TestBase {
+public class DateTimeSerializationTest {
     @Test
     public void testSerializeOffsetDateTime() throws Exception {
         var objectMapper = JsonMapper.builder()

--- a/src/src/test/java/com/relewise/client/TestBase.java
+++ b/src/src/test/java/com/relewise/client/TestBase.java
@@ -1,5 +1,8 @@
 package com.relewise.client;
 
+import org.junit.jupiter.api.Tag;
+
+@Tag("integration")
 public abstract class TestBase {
 
     public static String GetDatasetId() {


### PR DESCRIPTION
https://trello.com/c/mohcRXYf/21181-skip-integration-tests-in-dependabot-builds-for-the-java-sdk

## Summary

- Mark tests inheriting from `TestBase` as integration tests because they require `DATASET_ID` and `API_KEY`.
- Keep credential-independent tests in the unit-test path.
- Run only tests outside the `integration` group for Dependabot-triggered builds.
- Continue running the full test suite and test reporter for human-authored branches.
- Upgrade `actions/setup-java` to v5.6.0 and `dorny/test-reporter` to v3.

## Superseded Dependabot PRs

This PR includes the changes from #48 and #49, which were closed without merging:

- #48: upgrade `actions/setup-java` from v4 to v5.6.0.
- #49: upgrade `dorny/test-reporter` from v1 to v3.

Those Dependabot branches appeared to fail because the existing CI workflow ran credential-dependent integration tests. Dependabot-triggered workflows intentionally do not receive the repository's `DATASET_ID` and `API_KEY`, so the failures did not necessarily indicate incompatibilities in the upgraded actions.

The action upgrades were folded into this human-authored PR so they can be validated by the normal CI path, including the full integration suite with the existing repository secrets. This also avoids merging the CI fix first and then resolving overlapping workflow changes when applying the two dependency upgrades separately.

## Security rationale

The integration credentials are a dataset ID and Master API key for real customer datasets. They are not made available to Dependabot. Dependabot builds still generate and compile the SDK and run all tests that do not require those credentials.

## Validation

- `git diff --check` passed.
- All workflow action references were audited after the upgrades.
- Maven was unavailable locally, so runtime validation is delegated to this human-authored GitHub Actions build.
- No generated SDK code was changed.