### PR TITLE
chore(java): prepare release 1.14.0

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.relewise.client</groupId>
     <artifactId>relewise-sdk</artifactId>
-    <version>1.13.0</version>
+    <version>1.14.0</version>
     <name>relewise-sdk</name>
     <description>Relewise is a next generation personalization SaaS-platform, which offers functionality within product- and content recommendations and personalized search. This official SDK helps you interact with our API.</description>
     <inceptionYear>2023</inceptionYear>


### PR DESCRIPTION
https://trello.com/c/fvc3QhL8/21286-prepare-java-sdk-1140-release

## Summary
- Bump the Maven artifact version from 1.13.0 to 1.14.0.
- Prepare the batching improvements merged in #53 for release.

## Validation
- `mvn --batch-mode -DskipTests package --file src/pom.xml`
- `mvn resources:resources --file src/pom.xml`
- 13 focused unit tests passed, including `BatchingTest`.

Generation was not run because this changes release metadata only.